### PR TITLE
Push Mujoco Docker Image to Github Registry using Github Actions

### DIFF
--- a/.github/workflows/orom-backend-ci.yml
+++ b/.github/workflows/orom-backend-ci.yml
@@ -1,0 +1,34 @@
+name: OROM Backend CI Workflow
+
+env:
+  DOTNET_VERSION: '6.0.x'
+  REPO_NAME: ${{ github.event.repository.name }}
+  MUJOCO_DOCKERFILE: "Dockerfile_Mujoco"
+
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  push-mujoco-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Build and Push Image to Github Packages'
+        run: |
+          docker build -f ./docker/${{ env.MUJOCO_DOCKERFILE }} -t ghcr.io/${{ github.actor }}/${{ env.REPO_NAME }}:latest .
+          docker push ghcr.io/${{ github.actor }}/${{ env.REPO_NAME }}:latest

--- a/.github/workflows/orom-backend-ci.yml
+++ b/.github/workflows/orom-backend-ci.yml
@@ -5,7 +5,6 @@ env:
   REPO_NAME: ${{ github.event.repository.name }}
   MUJOCO_DOCKERFILE: "Dockerfile_Mujoco"
 
-
 on:
   push:
     branches:

--- a/docker/Dockerfile_Mujoco
+++ b/docker/Dockerfile_Mujoco
@@ -2,7 +2,7 @@ FROM python:3.9
 
 SHELL ["/bin/bash", "-c", "-o", "pipefail"]
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y x11-apps x11-utils libx11-dev
 
 


### PR DESCRIPTION
### 💫 Describe your changes
Adds a CI workflow to automate building and pushing Docker images for the OROM backend to GitHub Container Registry. The workflow triggers on main branch pushes and manual dispatch, ensuring the latest image is always available.

#### Github Packages vs Dockerhub
Using GitHub Packages for Docker images streamlines our CI/CD process by keeping everything within GitHub. Since our code, Dockerfile, and workflows are all in the same repository, GitHub Packages allows seamless integration with GitHub Actions, simplifying authentication and permissions management. It also enables us to track image versions alongside our codebase without needing external credentials or extra permissions setup, making it more efficient than using Docker Hub.

#### **Note**: Change Project Workflow permissions (settings->Actions->General)
To ensure our GitHub Actions workflow can push Docker images to GitHub Packages, we need to adjust the workflow permissions for the GITHUB_TOKEN. By setting the permissions to allow write access for packages, we enable GitHub to generate a token with the necessary rights for each commit. This change is essential for successfully authenticating and pushing images to the registry during the CI/CD process. 
![image](https://github.com/user-attachments/assets/a027e107-6eef-43d1-9ac2-915b6c9b18f8)

### 📋 Issue ticket number and link
**Solving Issue** #13 

### 📝WIP
-  Adapt code to pull the image (see scene_manager/views.py and scene_manager/utils.py)
