### PR TITLE
Enable DefaultRouter in DEBUG mode and refactor serializers for reference robots/objects

### DIFF
--- a/orom_backend/object_library/urls.py
+++ b/orom_backend/object_library/urls.py
@@ -1,9 +1,17 @@
 from django.urls import path, include
+from django.conf import settings
 from .views import (
     ReferenceRobotViewSet, ReferenceObjectViewSet
 )
-from rest_framework.routers import SimpleRouter
-router = SimpleRouter()
+
+# Use DefaultRouter if DEBUG is True, otherwise use SimpleRouter
+if settings.DEBUG:
+    from rest_framework.routers import DefaultRouter
+    router = DefaultRouter()
+else:
+    from rest_framework.routers import SimpleRouter
+    router = SimpleRouter()
+
 router.register('ref-robots', ReferenceRobotViewSet)
 router.register('ref-objects', ReferenceObjectViewSet)
 

--- a/orom_backend/scene_manager/serializers.py
+++ b/orom_backend/scene_manager/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import Scene, Object, Robot
+from object_library.models import ReferenceRobot, ReferenceObject
 from object_library.serializers import ReferenceRobotSerializer, ReferenceObjectSerializer
 
 
@@ -12,7 +13,7 @@ class SceneSerializer(serializers.ModelSerializer):
 
 class ObjectSerializer(serializers.ModelSerializer):
     # Nested serializer to also get information of reference object
-    object_reference = ReferenceObjectSerializer()
+    object_reference = serializers.PrimaryKeyRelatedField(queryset=ReferenceObject.objects.all())
 
     class Meta:
         model = Object
@@ -21,8 +22,7 @@ class ObjectSerializer(serializers.ModelSerializer):
 
 
 class RobotSerializer(serializers.ModelSerializer):
-    # Nested serializer to also get information of reference robot
-    robot_reference = ReferenceRobotSerializer()
+    robot_reference = serializers.PrimaryKeyRelatedField(queryset=ReferenceRobot.objects.all())
 
     class Meta:
         model = Robot

--- a/orom_backend/scene_manager/serializers.py
+++ b/orom_backend/scene_manager/serializers.py
@@ -12,10 +12,7 @@ class SceneSerializer(serializers.ModelSerializer):
 
 
 class ObjectSerializer(serializers.ModelSerializer):
-    # Nested serializer to also get information of reference object
-    object_reference = serializers.PrimaryKeyRelatedField(queryset=ReferenceObject.objects.all())
-
-    class Meta:
+    class Meta:      
         model = Object
         fields = '__all__'
 

--- a/orom_backend/scene_manager/urls.py
+++ b/orom_backend/scene_manager/urls.py
@@ -1,13 +1,21 @@
 from django.urls import path, include
+from django.conf import settings
 from .views import (
     ObjectViewSet, RobotViewSet, SceneViewSet, MujocoSimulationStart, MujocoSimulationStop
 )
-from rest_framework.routers import SimpleRouter
-router = SimpleRouter()
+
+
+# Use DefaultRouter if DEBUG is True, otherwise use SimpleRouter
+if settings.DEBUG:
+    from rest_framework.routers import DefaultRouter
+    router = DefaultRouter()
+else:
+    from rest_framework.routers import SimpleRouter
+    router = SimpleRouter()
+
 router.register('objects', ObjectViewSet)
 router.register('robots', RobotViewSet)
 router.register('scenes', SceneViewSet)
-
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
### 💫 Describe your changes
1. URL Routing with DefaultRouter in DEBUG Mode:

 - DefaultRouter Benefits: Automatically generates URL patterns for viewsets and provides a browsable API root for easier development.
 For Example: 
 http://localhost:8000/library/ref-robots/
![image](https://github.com/user-attachments/assets/34d7567c-bfc2-4fc5-acc6-9229d8498480)


2. Serializer Refactor:

 - Updated serializers to use PrimaryKeyRelatedField for handling object and robot references, fixing the problem with to save objects/robots in the scene manager

### 📋 Issue ticket number and link

Fixes openroboticmetaverse/mvp-webapp#52
